### PR TITLE
Bugfix: Export pac from a FixedProfile without bypass list do not work.

### DIFF
--- a/omega-pac/src/profiles.coffee
+++ b/omega-pac/src/profiles.coffee
@@ -253,7 +253,7 @@ module.exports = exports =
         body = [
           new U2.AST_Directive value: 'use strict'
         ]
-        if profile.bypassList
+        if profile.bypassList and profile.bypassList.length
           conditions = null
           for cond in profile.bypassList
             condition = Conditions.compile cond


### PR DESCRIPTION
If a fixedProfle without any bypass list, pac generation will fail. This cause
export pac failure, and switch profile which refer to this fixedprofile also not
work properly.

reproduce:
1. Import this options.
 `{"+ss":{"bypassList":[],"color":"#99ccee","fallbackProxy":{"host":"127.0.0.1","port":1999,"scheme":"socks5"},"name":"ss","profileType":"FixedProfile","revision":"14a767e19c3"},"-confirmDeletion":false,"-downloadInterval":-1,"-enableQuickSwitch":false,"-quickSwitchProfiles":[],"-refreshOnProfileChange":false,"-revertProxyChanges":false,"-showInspectMenu":true,"-startupProfileName":"","schemaVersion":2}`
2. try to export profile ss pac.
3. nothing happend. But the following logged to chrome console.
angular.min.js:92 TypeError: Cannot read property 'print' of null
    at chrome-extension://padekgcemlokbadohgkifijomclgjgif/js/omega_pac.min.js:17890:31
    at Object.with_parens (chrome-extension://padekgcemlokbadohgkifijomclgjgif/js/omega_pac.min.js:17443:23)
    at chrome-extension://padekgcemlokbadohgkifijomclgjgif/js/omega_pac.min.js:17889:20
    at doit (chrome-extension://padekgcemlokbadohgkifijomclgjgif/js/omega_pac.min.js:17553:17)
    at null.print (chrome-extension://padekgcemlokbadohgkifijomclgjgif/js/omega_pac.min.js:17559:17)
    at chrome-extension://padekgcemlokbadohgkifijomclgjgif/js/omega_pac.min.js:17702:26
    at Array.forEach (native)
    at display_body (chrome-extension://padekgcemlokbadohgkifijomclgjgif/js/omega_pac.min.js:17699:18)
    at chrome-extension://padekgcemlokbadohgkifijomclgjgif/js/omega_pac.min.js:17732:17
    at chrome-extension://padekgcemlokbadohgkifijomclgjgif/js/omega_pac.min.js:17435:23
