### PR TITLE
npm version must > 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ npm 2.x is required for this project.
 
 To build the project:
 
-    # Install node and npm first, then:
+    # Install node and npm first (make sure npm --version > 2.0), then:
+    
     sudo npm install -g grunt-cli bower
     # In the project folder:
     cd omega-build


### PR DESCRIPTION
Otherwise relative path in packages.json won't work, which maybe confusing for contributors which may use newest node but with older npm.