### PR TITLE
literal IPv6 address in a URL should be enclosed

### DIFF
--- a/omega-pac/src/conditions.coffee
+++ b/omega-pac/src/conditions.coffee
@@ -367,7 +367,7 @@ module.exports = exports =
             # This, however, will match IPv6 literals who also don't have dots.
             return (
               request.host == '127.0.0.1' or
-              request.host == '::1' or
+              request.host == '[::1]' or
               request.host.indexOf('.') < 0
             )
           else
@@ -389,7 +389,7 @@ module.exports = exports =
             left: new U2.AST_Binary(
               left: hostEquals '127.0.0.1'
               operator: '||'
-              right: hostEquals '::1'
+              right: hostEquals '[::1]'
             )
             operator: '||'
             right: new U2.AST_Binary(

--- a/omega-pac/src/profiles.coffee
+++ b/omega-pac/src/profiles.coffee
@@ -246,7 +246,7 @@ module.exports = exports =
           }
           {
             conditionType: 'BypassCondition'
-            pattern: '::1'
+            pattern: '[::1]'
           }
           {
             conditionType: 'BypassCondition'

--- a/omega-target-chromium-extension/src/upgrade.coffee
+++ b/omega-target-chromium-extension/src/upgrade.coffee
@@ -128,7 +128,7 @@ module.exports = (oldOptions, i18n) ->
             conditionType: "BypassCondition"
           }
           {
-            pattern: "::1"
+            pattern: "[::1]"
             conditionType: "BypassCondition"
           }
           {

--- a/omega-target/src/default_options.coffee
+++ b/omega-target/src/default_options.coffee
@@ -15,7 +15,7 @@ module.exports = ->
         conditionType: "BypassCondition"
       }
       {
-        pattern: "::1"
+        pattern: "[::1]"
         conditionType: "BypassCondition"
       }
       {


### PR DESCRIPTION
in "[" and "]" characters