### PR TITLE
WebExtension Proxy Script Fixes

### DIFF
--- a/omega-target-chromium-extension/src/js/omega_webext_proxy_script.js
+++ b/omega-target-chromium-extension/src/js/omega_webext_proxy_script.js
@@ -72,7 +72,6 @@ FindProxyForURL = (function () {
   }
 
   function init() {
-    browser.runtime.sendMessage({event: 'proxyScriptLoaded'});
     browser.runtime.onMessage.addListener(function(message) {
       if (message.event === 'proxyScriptStateChanged') {
         state = message.state;
@@ -85,5 +84,6 @@ FindProxyForURL = (function () {
         }
       }
     });
+    browser.runtime.sendMessage({event: 'proxyScriptLoaded'});
   }
 })();

--- a/omega-target-chromium-extension/src/js/omega_webext_proxy_script.js
+++ b/omega-target-chromium-extension/src/js/omega_webext_proxy_script.js
@@ -73,15 +73,19 @@ FindProxyForURL = (function () {
 
   function init() {
     browser.runtime.onMessage.addListener(function(message) {
-      if (message.event === 'proxyScriptStateChanged') {
-        state = message.state;
-        options = message.options;
-        if (!state.currentProfileName) {
-          activeProfile = state.tempProfile;
-        } else {
-          activeProfile = OmegaPac.Profiles.byName(state.currentProfileName,
-            options);
+      try {
+        if (message.event === 'proxyScriptStateChanged') {
+          state = message.state;
+          options = message.options;
+          if (!state.currentProfileName) {
+            activeProfile = state.tempProfile;
+          } else {
+            activeProfile = OmegaPac.Profiles.byName(state.currentProfileName,
+              options);
+          }
         }
+      } catch (err) {
+        warn('error on event: ' + message, err)
       }
     });
     browser.runtime.sendMessage({event: 'proxyScriptLoaded'});


### PR DESCRIPTION
* Fix potential race condition for proxyScriptLoaded event.
* Try sending messages 10 times! :wink:

You can try a pre-built, unsigned version against the tip of the branch. Make sure to rename it to `.xpi` after you download and then install the extension. NOTE: You will also need to [disable signing requirement](https://wiki.mozilla.org/Add-ons/Extension_Signing#FAQ), by changing `xpinstall.signatures.required` to `false` in `about:config`.

[proxy_switchyomega-2.5.1_4598afb8.zip](https://github.com/FelisCatus/SwitchyOmega/files/1206617/proxy_switchyomega-2.5.1_4598afb8.zip)