### PR TITLE
Output an icon size only

### DIFF
--- a/omega-target-chromium-extension/src/coffee/background.coffee
+++ b/omega-target-chromium-extension/src/coffee/background.coffee
@@ -48,19 +48,19 @@ drawIcon = (resultColor, profileColor) ->
       drawContext = document.getElementById('canvas-icon').getContext('2d')
 
     icon = {}
-    for size in [16, 19, 24, 32, 38]
-      drawContext.scale(size, size)
-      drawContext.clearRect(0, 0, 1, 1)
-      if resultColor?
-        drawOmega drawContext, resultColor, profileColor
-      else
-        drawOmega drawContext, profileColor
-      drawContext.setTransform(1, 0, 0, 1, 0, 0)
-      icon[size] = drawContext.getImageData(0, 0, size, size)
-      if icon[size].data[3] == 255
-        # Some browsers may replace the image data with a opaque white image to
-        # resist fingerprinting. In that case the icon cannot be drawn.
-        throw new Error('Icon drawing blocked by privacy.resistFingerprinting.')
+    size = 32
+    drawContext.scale(size, size)
+    drawContext.clearRect(0, 0, 1, 1)
+    if resultColor?
+      drawOmega drawContext, resultColor, profileColor
+    else
+      drawOmega drawContext, profileColor
+    drawContext.setTransform(1, 0, 0, 1, 0, 0)
+    icon = drawContext.getImageData(0, 0, size, size)
+    if icon.data[3] == 255
+      # Some browsers may replace the image data with a opaque white image to
+      # resist fingerprinting. In that case the icon cannot be drawn.
+      throw new Error('Icon drawing blocked by privacy.resistFingerprinting.')
   catch e
     if not drawError?
       drawError = e


### PR DESCRIPTION
### What does this PR do?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature

I think that outputting multiple sizes is unnecessary and it brings more processing time (CPU times, I see a big time at Firefox Nightly's `IconDetails.normalize`).
High resolution display is untested.

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setIcon
https://developer.chrome.com/extensions/browserAction

#### Compatibility

Is this PR compatible with old versions? Can users simply upgrade the extension?
Yes.
Please describe any possible breaking changes (or surprising UX differences).
Should not. Firefox Nightly tested.

#### Screenshots (if applicable)
N/A.
