### PR TITLE
[idea] Less icon refresh

### DIFF
--- a/omega-target-chromium-extension/src/module/tabs.coffee
+++ b/omega-target-chromium-extension/src/module/tabs.coffee
@@ -4,6 +4,7 @@ class ChromeTabs
 
   constructor: (@actionForUrl) ->
     @_dirtyTabs = {}
+    @_iconUpdatetime = {}
     return
 
   ignoreError: ->
@@ -35,7 +36,7 @@ class ChromeTabs
     if @_dirtyTabs.hasOwnProperty(tab.id)
       delete @_dirtyTabs[tab.id]
     else if not changeInfo.url?
-      if changeInfo.status? and changeInfo.status != 'loading'
+      if changeInfo.status == "complete"
         return
     @processTab(tab, changeInfo)
 
@@ -74,6 +75,11 @@ class ChromeTabs
 
   setIcon: (icon, tabId) ->
     return unless icon?
+    ctime = new Date().getTime()
+    if @_iconUpdatetime[tabId]? and (ctime - @_iconUpdatetime[tabId]) < 1000
+      return # skip if last update < 1000ms
+    else
+      @_iconUpdatetime[tabId] = ctime
     if tabId?
       params = {
         imageData: icon


### PR DESCRIPTION
### What does this PR do?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature

The extension is easy to use, but it is also huge and I feel a performance pressure. When I analyze performance (profiler & debugging) for this extension, I see that the icon refresh seems to be a big time, it may happen multiple times in a short time, and it seems to cache less.

The code change attempts to limit more than one change in one second. A better approach might be to reduce the trigger or use some queue like LIFO (but discard older).

#### Compatibility

Is this PR compatible with old versions? Can users simply upgrade the extension?
Should be yes.
Please describe any possible breaking changes (or surprising UX differences).
This may cause the icon refresh stutter, although I didn't see it, and the switch tabs should refresh it.

#### Screenshots (if applicable)
N/A.
