### PR TITLE
Trivial refines

### DIFF
--- a/omega-locales/en_US/LC_MESSAGES/omega-web.po
+++ b/omega-locales/en_US/LC_MESSAGES/omega-web.po
@@ -242,6 +242,9 @@ msgstr "Import/Export"
 msgid "options_newProfile"
 msgstr "New profile…"
 
+msgid "options_actions"
+msgstr "Actions"
+
 msgid "options_apply"
 msgstr "Apply changes"
 

--- a/omega-locales/zh_CN/LC_MESSAGES/omega-web.po
+++ b/omega-locales/zh_CN/LC_MESSAGES/omega-web.po
@@ -224,6 +224,9 @@ msgstr "导入/导出"
 msgid "options_newProfile"
 msgstr "新建情景模式…"
 
+msgid "options_actions"
+msgstr "操作"
+
 msgid "options_apply"
 msgstr "应用选项"
 

--- a/omega-target-chromium-extension/src/module/tabs.coffee
+++ b/omega-target-chromium-extension/src/module/tabs.coffee
@@ -25,18 +25,15 @@ class ChromeTabs
       tabs.forEach (tab) =>
         @_dirtyTabs[tab.id] = tab.id
         @onUpdated tab.id, {}, tab if tab.active
-    if chrome.browserAction.setPopup?
-      chrome.browserAction.setTitle({title: action.title})
-    else
-      chrome.browserAction.setTitle({title: action.shortTitle})
+    title = if @_canSetPopup() then action.title else action.shortTitle
+    chrome.browserAction.setTitle({title: title})
     @setIcon(action.icon)
 
   onUpdated: (tabId, changeInfo, tab) ->
     if @_dirtyTabs.hasOwnProperty(tab.id)
       delete @_dirtyTabs[tab.id]
-    else if not changeInfo.url?
-      if changeInfo.status? and changeInfo.status != 'loading'
-        return
+    else if not changeInfo.url? and changeInfo.status == "complete"
+      return
     @processTab(tab, changeInfo)
 
   processTab: (tab, changeInfo) ->
@@ -58,10 +55,8 @@ class ChromeTabs
         @clearIcon tab.id
         return
       @setIcon(action.icon, tab.id)
-      if chrome.browserAction.setPopup?
-        chrome.browserAction.setTitle({title: action.title, tabId: tab.id})
-      else
-        chrome.browserAction.setTitle({title: action.shortTitle, tabId: tab.id})
+      title = if @_canSetPopup() then action.title else action.shortTitle
+      return chrome.browserAction.setTitle({title: title, tabId: tab.id})
 
   setTabBadge: (tab, badge) ->
     @_badgeTab ?= {}
@@ -74,16 +69,14 @@ class ChromeTabs
 
   setIcon: (icon, tabId) ->
     return unless icon?
-    if tabId?
-      params = {
-        imageData: icon
-        tabId: tabId
-      }
-    else
-      params = {
-        imageData: icon
-      }
+    params = {
+      imageData: icon
+    }
+    params.tabId = tabId if tabId?
     @_chromeSetIcon(params)
+
+  _canSetPopup: ->
+    chrome.browserAction.setPopup?
 
   _chromeSetIcon: (params) ->
     try

--- a/omega-web/src/less/popup.less
+++ b/omega-web/src/less/popup.less
@@ -86,6 +86,10 @@ li > a {
   box-shadow: none !important;
 }
 
+ul.dropdown-menu {
+  position: relative;
+}
+
 li .dropdown-menu {
   position: static;
   top: initial;

--- a/omega-web/src/options.jade
+++ b/omega-web/src/options.jade
@@ -42,7 +42,7 @@ html(lang='en' ng-controller='MasterCtrl' ng-csp)
               = ' '
               span {{'options_newProfile' | tr}}
           li.divider
-          li.nav-header Actions
+          li.nav-header {{'options_actions' | tr}}
           li
             a.btn-default.btn.align-initial(role='button' ng-click='applyOptions()'
                 ng-class='{"btn-success": optionsDirty}')

--- a/omega-web/src/partials/profile_pac.jade
+++ b/omega-web/src/partials/profile_pac.jade
@@ -37,4 +37,4 @@ div(ng-controller='PacProfileCtrl')
       p.alert.alert-danger.width-limit(ng-show='profile.pacUrl && !profile.lastUpdate')
         | {{'options_pacScriptObsolete' | tr}}
       textarea.monospace.form-control.width-limit(ng-model='profile.pacScript' rows=20
-        ng-disabled='pacUrlCtrl.ctrl.$invalid || !!profile.pacUrl')
+        ng-readonly='pacUrlCtrl.ctrl.$invalid || !!profile.pacUrl')

--- a/omega-web/src/partials/profile_rule_list.jade
+++ b/omega-web/src/partials/profile_rule_list.jade
@@ -28,5 +28,5 @@ div(ng-controller='RuleListProfileCtrl')
           ladda='updatingProfile[profile.name]' data-spinner-color="#000000")
         | #[span.glyphicon.glyphicon-download-alt] {{'options_downloadProfileNow' | tr}}
     textarea.monospace.form-control.width-limit(ng-model='profile.ruleList' rows=20
-      ng-disabled='!!profile.sourceUrl')
+      ng-readonly='!!profile.sourceUrl')
 


### PR DESCRIPTION
### What does this PR do?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature

1. 补全缺失的翻译。没改其他语言（太多了），不知道翻译平台能否自动补全。正常来说应该是一个en.pot和一堆.po。
2. 代码逻辑简化。没使用直接`title`的参数简写，那好像是ES6的某个语法，没查到名称和兼容性。
3. 修改样式后，弹出面板中的‘网络异常’域名添加，下拉列表能正常扩展弹出窗的大小了。
4. 之前允许用户查看、选中，但无法复制已订阅规则的内容，操作不友好。
仅测试了Firefox Nightly。

#### Compatibility

Is this PR compatible with old versions? Can users simply upgrade the extension?
Yes.
Please describe any possible breaking changes (or surprising UX differences).
Better UX.
