### PR TITLE
Fix that WebRequestMonitor.tabInfo is never removed

### DIFF
--- a/omega-target-chromium-extension/src/module/web_request_monitor.coffee
+++ b/omega-target-chromium-extension/src/module/web_request_monitor.coffee
@@ -128,8 +128,8 @@ module.exports = class WebRequestMonitor
     chrome.tabs.onCreated.addListener (tab) =>
       return unless tab.id
       @tabInfo[tab.id] = @_newTabInfo()
-    chrome.tabs.onRemoved.addListener (tab) =>
-      delete @tabInfo[tab.id]
+    chrome.tabs.onRemoved.addListener (tabId) =>
+      delete @tabInfo[tabId]
     chrome.tabs.onReplaced?.addListener (added, removed) =>
       @tabInfo[added] ?= @_newTabInfo()
       delete @tabInfo[removed]


### PR DESCRIPTION
### What does this PR do?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature

I noticed that when browser is running for longer time (days/weeks), the extension has masive memory footprint (hundreds of MB).
I investigated a little and noticed that WebRequestMonitor.tabInfo is never removed,
and it is because chrome.tabs.onRemoved.addListener had wrong parameter.

#### Compatibility

yes
