### PR TITLE
Add credentials via ProxyInfo.proxyAuthorizationHeader for HTTP/HTTPS proxy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:7.10
+      - image: circleci/node:12.9.1
 
     working_directory: ~/repo
 

--- a/omega-target-chromium-extension/src/module/proxy/proxy_impl_listener.coffee
+++ b/omega-target-chromium-extension/src/module/proxy/proxy_impl_listener.coffee
@@ -84,13 +84,13 @@ class ListenerProxyImpl extends ProxyImpl
     # Send Proxy-Authorization header without challenge
     # This is required when HTTP/HTTPS proxy does not response 401/407
     # when credential is invalid or missing
-    # In this case, webRequest.onAuthRequired will never be fired 
+    # webRequest.onAuthRequired is not fired 
     # The header must be supplied via proxyAuthorizationHeader
     if proxyInfo.type == 'http' or proxyInfo.type == 'https'
       if auth.username and auth.password
         header = "Basic " + btoa(auth.username + ':' + auth.password)
         proxyInfo.proxyAuthorizationHeader = header
-    # TODO: Maybe we need make it configurable although it is not necessary 
+
 
     return [proxyInfo]
 

--- a/omega-target-chromium-extension/src/module/proxy/proxy_impl_listener.coffee
+++ b/omega-target-chromium-extension/src/module/proxy/proxy_impl_listener.coffee
@@ -84,7 +84,7 @@ class ListenerProxyImpl extends ProxyImpl
     # Send Proxy-Authorization header without challenge
     # This is required when HTTP/HTTPS proxy does not response 401/407
     # when credential is invalid or missing
-    # webRequest.onAuthRequired is not fired 
+    # webRequest.onAuthRequired is not fired in this case
     # The header must be supplied via proxyAuthorizationHeader
     if proxyInfo.type == 'http' or proxyInfo.type == 'https'
       if auth.username and auth.password

--- a/omega-target-chromium-extension/src/module/proxy/proxy_impl_listener.coffee
+++ b/omega-target-chromium-extension/src/module/proxy/proxy_impl_listener.coffee
@@ -82,8 +82,8 @@ class ListenerProxyImpl extends ProxyImpl
     # the SOCKS4a extension may simply refuse to work.
     
     # Send Proxy-Authorization header without challenge
-    # This is required when HTTPS proxy works in disguise mode
-    # Disguised proxy does not response 401/407 when credential is invalid or missing
+    # This is required when HTTP/HTTPS proxy does not response 401/407
+    # when credential is invalid or missing
     # In this case, webRequest.onAuthRequired will never be fired 
     # The header must be supplied via proxyAuthorizationHeader
     if proxyInfo.type == 'http' or proxyInfo.type == 'https'

--- a/omega-target-chromium-extension/src/module/proxy/proxy_impl_listener.coffee
+++ b/omega-target-chromium-extension/src/module/proxy/proxy_impl_listener.coffee
@@ -80,6 +80,17 @@ class ListenerProxyImpl extends ProxyImpl
     # TODO(catus): Maybe allow proxyDNS for socks4? Server may support SOCKS4a.
     # It cannot default to true though, since SOCKS4 servers that does not have
     # the SOCKS4a extension may simply refuse to work.
+    
+    # Send Proxy-Authorization header without challenge
+    # This is required when HTTPS proxy works in disguise mode
+    # Disguised proxy does not response 401/407 when credential is invalid or missing
+    # In this case, webRequest.onAuthRequired will never be fired 
+    # The header must be supplied via proxyAuthorizationHeader
+    if proxyInfo.type == 'http' or proxyInfo.type == 'https'
+      if auth.username and auth.password
+        header = "Basic " + btoa(auth.username + ':' + auth.password)
+        proxyInfo.proxyAuthorizationHeader = header
+    # TODO: Maybe we need make it configurable although it is not necessary 
 
     return [proxyInfo]
 


### PR DESCRIPTION

### What does this PR do?
- [ ] Bug fix
- [ ] Improvement
- [x] New feature

I am developer of V-Proxy, a disguised HTTPS proxy, which will be opened source soon.
V-Proxy works as a reverse proxy in normal cases to pretend as an HTTPS web site.
Only when V-Proxy receives an HTTPS proxy request whose credential is valid, it behaves as an HTTPS proxy server.

To avoid surveillants detect V-Proxy handles HTTPS proxy requests,  V-Proxy behaves as reverse proxy if the credentials of HTTPS proxy requests are missing or incorrect.
As a result,  V-Proxy will not response HTTP 401 nor 407 errors.  `webRequest.onAuthRequired` will never be fired.

To make SwitchyOmega work with V-Proxy, `Proxy-Authorization` header must be sent without challenges  Hence, this pull request set basic authentication header via `ProxyInfo.proxyAuthorizationHeader`. https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/ProxyInfo


#### Compatibility

It is compatible with old versions.  if classic HTTPS proxy responses HTTP 401/407, `webRequest.onAuthRequired` is still fired.

`ProxyInfo.proxyAuthorizationHeader` is only available in Firefox at this moment. But it will not break Chrome and I will try to push Chrome to add the same property.

#### P.S.

 The current image `circleci/node:7.10` in `.circleci/config.yml` is too old to work with new version of `web-ext`.  It causes an error in CircleCI, hence I updated it.

