### PR TITLE
Add credentials in  proxyInfo.proxyAuthorizationHeader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:7.10
+      - image: circleci/node:lts
 
     working_directory: ~/repo
 

--- a/omega-locales/en_US/LC_MESSAGES/omega-web.po
+++ b/omega-locales/en_US/LC_MESSAGES/omega-web.po
@@ -15,7 +15,7 @@ msgstr ""
 "X-Generator: Weblate 3.0.1\n"
 
 msgid "appNameShort"
-msgstr "SwitchyOmega"
+msgstr "SwitchyOmega for VProxy"
 
 msgid "manifest_app_name"
 msgstr "Proxy SwitchyOmega"

--- a/omega-locales/zh_CN/LC_MESSAGES/omega-web.po
+++ b/omega-locales/zh_CN/LC_MESSAGES/omega-web.po
@@ -15,7 +15,7 @@ msgstr ""
 "X-Generator: Weblate 3.5-dev\n"
 
 msgid "appNameShort"
-msgstr "SwitchyOmega"
+msgstr "SwitchyOmega for VProxy"
 
 msgid "manifest_app_name"
 msgstr "Proxy SwitchyOmega"

--- a/omega-target-chromium-extension/overlay/manifest.json
+++ b/omega-target-chromium-extension/overlay/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "SwitchyOmega for VProxy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "__MSG_manifest_app_description__",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkhwZJT76btQ04EEMOFtZPLESD1TmSVjbLjs0OyesD9Ht8YllFPfJ3qmtbSQGVuvmxH1GK/jUO2QcEWb8bHuOjoRlq20fi5j5Aq90O8FKET+y5D8PxCyi3WmnquiEwaE5cNmaCsw/G2JlO+bZOtdQ/QKOvMxBAegABYimEGfSvCMVUEvpymys0gBhLoch72zPAiJUBkf0z8BtjYTueMRcRXkrSeRPLygUDQnZ1TkQWMYYBp/zqpD5ggxytAklEMQzR9Hn0lqu5s7iuUAgihbysPn/8Wh00Zj5FySpK//KcpG3JS7UWxC28oSt8z5ZR3YimnX+HX3P36V0mC1pgM4o7wIDAQAB",
   "icons": {

--- a/omega-target-chromium-extension/overlay/manifest.json
+++ b/omega-target-chromium-extension/overlay/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
-  "name": "__MSG_manifest_app_name__",
-  "version": "2.5.21",
+  "name": "SwitchyOmega for VProxy",
+  "version": "1.0.0",
   "description": "__MSG_manifest_app_description__",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkhwZJT76btQ04EEMOFtZPLESD1TmSVjbLjs0OyesD9Ht8YllFPfJ3qmtbSQGVuvmxH1GK/jUO2QcEWb8bHuOjoRlq20fi5j5Aq90O8FKET+y5D8PxCyi3WmnquiEwaE5cNmaCsw/G2JlO+bZOtdQ/QKOvMxBAegABYimEGfSvCMVUEvpymys0gBhLoch72zPAiJUBkf0z8BtjYTueMRcRXkrSeRPLygUDQnZ1TkQWMYYBp/zqpD5ggxytAklEMQzR9Hn0lqu5s7iuUAgihbysPn/8Wh00Zj5FySpK//KcpG3JS7UWxC28oSt8z5ZR3YimnX+HX3P36V0mC1pgM4o7wIDAQAB",
   "icons": {
@@ -57,7 +57,7 @@
   },
   "applications": {
     "gecko": {
-      "id": "switchyomega@feliscatus.addons.mozilla.org",
+      "id": "vproxy.dev@yandex.com",
       "strict_min_version": "55.0a1"
     }
   }

--- a/omega-target-chromium-extension/src/module/proxy/proxy_impl_listener.coffee
+++ b/omega-target-chromium-extension/src/module/proxy/proxy_impl_listener.coffee
@@ -80,6 +80,11 @@ class ListenerProxyImpl extends ProxyImpl
     # TODO(catus): Maybe allow proxyDNS for socks4? Server may support SOCKS4a.
     # It cannot default to true though, since SOCKS4 servers that does not have
     # the SOCKS4a extension may simply refuse to work.
+    
+    if proxyInfo.type == 'http' or proxyInfo.type == 'https'
+      if auth.username and auth.password
+        header = "Basic " + btoa(auth.username + ':' + auth.password)
+        proxyInfo.proxyAuthorizationHeader = header
 
     return [proxyInfo]
 

--- a/omega-web/src/partials/about.jade
+++ b/omega-web/src/partials/about.jade
@@ -10,7 +10,7 @@ section
     .media-left
       img.media-object(src='img/icons/omega-action-32.png')
     .media-body
-      h4.media-heading {{'appNameShort' | tr}}
+      h4.media-heading {{'SwitchyOmega for VProxy'}}
       p {{'about_app_description' | tr}}
 section
   p

--- a/omega-web/src/partials/about.jade
+++ b/omega-web/src/partials/about.jade
@@ -10,7 +10,7 @@ section
     .media-left
       img.media-object(src='img/icons/omega-action-32.png')
     .media-body
-      h4.media-heading {{'SwitchyOmega for VProxy'}}
+      h4.media-heading {{'appNameShort' | tr}}
       p {{'about_app_description' | tr}}
 section
   p


### PR DESCRIPTION
### What does this PR do?
- [ ] Bug fix
- [ ] Improvement
- [x] New feature

I am developer of [VProxy](https://github.com/vproxy666/v-proxy), an HTTPS Forward proxy hidden in HTTPS web site.

VProxy pretends to be an HTTPS web site and only handles HTTPS proxy requests when the supplied credentials are valid.  VProxy does not support challenge–response authentication for its HTTPS proxy because that would make it possible to detect it is running an HTTPS proxy.

As a result, VProxy works as reverse proxy when the credentials in HTTPS proxy request are missing or invalid.  In this case, VProxy does not response HTTP error code `401` or `407` error and SwitchyOmega cannot work with it (Because it relies on `webRequest.onAuthRequired` to supply credentials.

This PR set basic authentization header via `proxyInfo.proxyAuthorizationHeader` (https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/ProxyInfo).

`Proxy-Authorization` HTTP header will be sent to HTTP/HTTPS proxy without challenge–response authentication any more.

#### Compatibility

This PR does not involve breaking changes.  When HTTP/HTTPS proxy responses `401` or `407` error, `webRequest.onAuthRequired` is still fired and the logic is the same as before.

At this moment `proxyInfo.proxyAuthorizationHeader`  is only supported by Firefox, we will try to push it to Chrome as well. Anyway, it does not break Chrome version.

#### P.S.

The circleci image was too old to build the project because new version of some dependencies cannot work with the old one. Hence I updated the circleci image version as well.