### PR TITLE
Prefer pendingUrl than url.

### DIFF
--- a/omega-target-chromium-extension/src/coffee/background.coffee
+++ b/omega-target-chromium-extension/src/coffee/background.coffee
@@ -320,12 +320,15 @@ encodeError = (obj) ->
 refreshActivePageIfEnabled = ->
   return if localStorage['omega.local.refreshOnProfileChange'] == 'false'
   chrome.tabs.query {active: true, lastFocusedWindow: true}, (tabs) ->
-    url = tabs[0].url
+    url = tabs[0].pendingUrl || tabs[0].url
     return if not url
     return if url.substr(0, 6) == 'chrome'
     return if url.substr(0, 6) == 'about:'
     return if url.substr(0, 4) == 'moz-'
-    chrome.tabs.reload(tabs[0].id, {bypassCache: true})
+    if tabs[0].pendingUrl
+      chrome.tabs.update(tabs[0].id, {url})
+    else
+      chrome.tabs.reload(tabs[0].id, {bypassCache: true})
 
 chrome.runtime.onMessage.addListener (request, sender, respond) ->
   return unless request and request.method

--- a/omega-target-chromium-extension/src/coffee/omega_target_web.coffee
+++ b/omega-target-chromium-extension/src/coffee/omega_target_web.coffee
@@ -136,8 +136,12 @@ angular.module('omegaTarget', []).factory 'omegaTarget', ($q) ->
     refreshActivePage: ->
       d = $q['defer']()
       chrome.tabs.query {active: true, lastFocusedWindow: true}, (tabs) ->
-        if tabs[0].url and not isChromeUrl(tabs[0].url)
-          chrome.tabs.reload(tabs[0].id, {bypassCache: true})
+        url = tabs[0].pendingUrl || tabs[0].url
+        if url and not isChromeUrl(url)
+          if tabs[0].pendingUrl
+            chrome.tabs.update(tabs[0].id, {url})
+          else
+            chrome.tabs.reload(tabs[0].id, {bypassCache: true})
         d.resolve()
       return d.promise
     openManage: ->

--- a/omega-target-chromium-extension/src/js/omega_target_popup.js
+++ b/omega-target-chromium-extension/src/js/omega_target_popup.js
@@ -66,8 +66,8 @@ OmegaTargetPopup = {
   },
   getActivePageInfo: function(cb) {
     chrome.tabs.query({active: true, lastFocusedWindow: true}, function (tabs) {
-      if (tabs.length === 0 || !tabs[0].url) return cb();
-      var args = {tabId: tabs[0].id, url: tabs[0].url};
+      if (tabs.length === 0 || (!tabs[0].url && !tabs[0].pendingUrl)) return cb();
+      var args = {tabId: tabs[0].id, url: tabs[0].pendingUrl || tabs[0].url};
       callBackground('getPageInfo', [args], cb)
     });
   },

--- a/omega-target-chromium-extension/src/module/options.coffee
+++ b/omega-target-chromium-extension/src/module/options.coffee
@@ -101,12 +101,15 @@ class ChromeOptions extends OmegaTarget.Options
           index = (index + 1) % profiles.length
           @applyProfile(profiles[index]).then =>
             if @_options['-refreshOnProfileChange']
-              url = tab.url
+              url = tab.pendingUrl || tab.url
               return if not url
               return if url.substr(0, 6) == 'chrome'
               return if url.substr(0, 6) == 'about:'
               return if url.substr(0, 4) == 'moz-'
-              chrome.tabs.reload(tab.id)
+              if tab.pendingUrl
+                chrome.tabs.update(tab.id, {url})
+              else
+                chrome.tabs.reload(tab.id)
     else
       chrome.browserAction.setPopup({popup: 'popup/index.html'})
 


### PR DESCRIPTION
### What does this PR do?
- [*] Improvement

Get url from `tab.pendingUrl` while tab is loading.

It's useful when we access an unreachable url by current proxy.

Formerly, we have to waiting for the page loading failed... It may spent tens of seconds or more. Then we can view the host at the SwitchyOmega popup.

Now, we can get the host immediately and we can set the temporary rule, the rule will effect immediately too and auto reload the tab with the pendingUrl.

#### Compatibility

This feature is works in Chrome 79+ (because of `pendingUrl` is added since that)

But it won't break the original behavior in old versions.
