### PR TITLE
Fix popup show no profile

### DIFF
--- a/omega-web/src/popup/js/profiles.js
+++ b/omega-web/src/popup/js/profiles.js
@@ -7,24 +7,6 @@
     .cloneNode(true);
   profileTemplate.removeAttribute('id');
 
-  var iconForProfileType = {
-    'DirectProfile': 'glyphicon-transfer',
-    'SystemProfile': 'glyphicon-off',
-    'AutoDetectProfile': 'glyphicon-file',
-    'FixedProfile': 'glyphicon-globe',
-    'PacProfile': 'glyphicon-file',
-    'VirtualProfile': 'glyphicon-question-sign',
-    'RuleListProfile': 'glyphicon-list',
-    'SwitchProfile': 'glyphicon-retweet',
-  };
-  var orderForType = {
-    'FixedProfile': -2000,
-    'PacProfile': -1000,
-    'VirtualProfile': 1000,
-    'SwitchProfile': 2000,
-    'RuleListProfile': 3000,
-  };
-
   return;
 
   function updateMenuByState() {
@@ -39,6 +21,14 @@
   }
 
   function compareProfile(a, b) {
+    var orderForType = {
+      'FixedProfile': -2000,
+      'PacProfile': -1000,
+      'VirtualProfile': 1000,
+      'SwitchProfile': 2000,
+      'RuleListProfile': 3000,
+    };
+    
     var diff;
     diff = (orderForType[a.profileType] | 0) - (orderForType[b.profileType] | 0);
     if (diff !== 0) {
@@ -186,6 +176,17 @@
   }
 
   function createMenuItemForProfile(profile, profiles) {
+    var iconForProfileType = {
+      'DirectProfile': 'glyphicon-transfer',
+      'SystemProfile': 'glyphicon-off',
+      'AutoDetectProfile': 'glyphicon-file',
+      'FixedProfile': 'glyphicon-globe',
+      'PacProfile': 'glyphicon-file',
+      'VirtualProfile': 'glyphicon-question-sign',
+      'RuleListProfile': 'glyphicon-list',
+      'SwitchProfile': 'glyphicon-retweet',
+    };
+
     var profileDisp = profileTemplate.cloneNode(true);
     var text = OmegaTargetPopup.getMessage('profile_' + profile.name) ||
       profile.name;


### PR DESCRIPTION
### What does this PR do?
- [x] Bug fix [#2337]
- [ ] Improvement
- [ ] New feature

(Note: Translations and typo fixes should be done on https://hosted.weblate.org/projects/switchyomega/ instead of PR.)

In some case there may be no profile shown in popup menu like

![776769539a6d95448135782a5f74ebd](https://user-images.githubusercontent.com/28624661/205855415-d71325a4-eea8-4abc-bd30-ead55335e0fc.png)

And we can find error like this

```
Uncaught TypeError: Cannot read properties of undefined (reading 'FixedProfile')
    at compareProfile (profiles.js:43:25)
    at Array.sort (<anonymous>)
    at addProfilesItems (profiles.js:145:8)
    at updateMenuByState (profiles.js:36:5)
    at v.ready (script.min.js:formatted:95:14)
    at profiles.js:2:11
    at profiles.js:283:3
```

Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var#var_hoisting

#### Compatibility

- Is this PR compatible with old versions? Y
- Can users simply upgrade the extension? Y
